### PR TITLE
Fixes the jscs config and dependencies so the tests run and pass

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -6,7 +6,6 @@
   "additionalRules": [
     "node_modules/jscs-trailing-comma/rules/*.js"
   ],
-  "requireTrailingCommaInExpandedLiterals": true,
   "requireCurlyBraces": [
     "if",
     "else",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,10 @@
     "coveralls": "cat ./coverage/lcov.info | COVERALLS_SERVICE_NAME=\"travis-ci\" ./node_modules/.bin/coveralls",
     "test": "./node_modules/.bin/gulp test"
   },
-  "dependencies": {
-    "did-you-mean": "0.0.0"
-  },
   "devDependencies": {
     "chai": "^1.9.1",
     "coveralls": "^2.10.0",
+    "did-you-mean": "0.0.1",
     "gulp": "^3.6.2",
     "gulp-concat": "^2.2.0",
     "gulp-ignore": "^1.1.0",
@@ -46,7 +44,6 @@
     "gulp-jshint": "^1.8.4",
     "gulp-mocha": "^0.4.1",
     "gulp-rename": "^1.2.0",
-    "jscs-trailing-comma": "^0.3.0",
     "sinon": "^1.10.3",
     "sinon-chai": "^2.5.0",
     "vinyl": "^0.2.3"

--- a/package.json
+++ b/package.json
@@ -32,10 +32,12 @@
     "coveralls": "cat ./coverage/lcov.info | COVERALLS_SERVICE_NAME=\"travis-ci\" ./node_modules/.bin/coveralls",
     "test": "./node_modules/.bin/gulp test"
   },
+  "dependencies": {
+    "did-you-mean": "0.0.0"
+  },
   "devDependencies": {
     "chai": "^1.9.1",
     "coveralls": "^2.10.0",
-    "did-you-mean": "0.0.1",
     "gulp": "^3.6.2",
     "gulp-concat": "^2.2.0",
     "gulp-ignore": "^1.1.0",


### PR DESCRIPTION
I couldn't get the tests to run on a fresh install. So I:
- Removed `jscs-trailing-comma` to fix a double jscs rule registration
- Removed the `requireTrailingCommaInExpandedLiterals` (which was probably implemented by `jscs-trailing-comma`)

It's likely I went about this all wrong, but I couldn't figure out why the rule `disallowTrailingComma` was being registered twice. So I did the next best thing to get the tests running.
### Details

I couldn't run the tests because of a jscs rule that was being registered twice:

```
[12:53:01] 'jscs' errored after 73 ms
[12:53:01] AssertionError: Rule "disallowTrailingComma" is already registered
    at NodeConfiguration.Configuration.registerRule (/repos/react-mistyped-props/node_modules/gulp-jscs/node_modules/jscs/lib/config/configuration.js:486:5)
    at NodeConfiguration.Configuration._loadAdditionalRule (/repos/react-mistyped-props/node_modules/gulp-jscs/node_modules/jscs/lib/config/configuration.js:435:10)
    at NodeConfiguration.<anonymous> (/repos/react-mistyped-props/node_modules/gulp-jscs/node_modules/jscs/lib/config/node-configuration.js:111:57)
    at Array.forEach (native)
    at NodeConfiguration._loadAdditionalRule (/repos/react-mistyped-props/node_modules/gulp-jscs/node_modules/jscs/lib/config/node-configuration.js:109:65)
    at Array.forEach (native)
    at NodeConfiguration.Configuration._processConfig (/repos/react-mistyped-props/node_modules/gulp-jscs/node_modules/jscs/lib/config/configuration.js:315:33)
    at NodeConfiguration.Configuration.load (/repos/react-mistyped-props/node_modules/gulp-jscs/node_modules/jscs/lib/config/configuration.js:60:29)
    at StringChecker.configure (/repos/react-mistyped-props/node_modules/gulp-jscs/node_modules/jscs/lib/string-checker.js:66:29)
    at Checker.configure (/repos/react-mistyped-props/node_modules/gulp-jscs/node_modules/jscs/lib/checker.js:26:39)
[12:53:01] Finished 'jshint' after 233 ms
npm ERR! Test failed.  See above for more details.
```

I removed `jscs-trailing-comma` then got this:

```
/repos/react-mistyped-props/gulpfile.js:19
    throw error;
          ^
Error: Unsupported rule: requireTrailingCommaInExpandedLiterals at index.js :
     1 |module.exports = {
--------^
     2 |    MistypedPropsMixin: require("lib/MistypedPropsMixin"),
     3 |};

Unsupported rule: requireTrailingCommaInExpandedLiterals at gulpfile.js :
     1 |"use strict";
--------^
     2 |
     3 |var gulp = require("gulp");

Unsupported rule: requireTrailingCommaInExpandedLiterals at MixinSpec.js :
     1 |"use strict";
--------^
     2 |
     3 |describe("MistypedPropsMixin", function () {

Unsupported rule: requireTrailingCommaInExpandedLiterals at _init.js :
     1 |var chai = require("chai");
--------^
     2 |
     3 |chai.should();
npm ERR! Test failed.  See above for more details.
```

After removing that config, the tests ran and passed:

```
  MistypedPropsMixin
    when component will mount
      ✓ should warn for mistyped properties 
    when component will receive new props
      ✓ should warn for mistyped properties 


  2 passing (32ms)

------------------------------|-----------|-----------|-----------|-----------|
File                          |   % Stmts |% Branches |   % Funcs |   % Lines |
------------------------------|-----------|-----------|-----------|-----------|
   lib/                       |       100 |        50 |       100 |       100 |
      MistypedPropsMixin.js   |       100 |        50 |       100 |       100 |
   lib/utils/                 |       100 |       100 |       100 |       100 |
      checkForMistypedKeys.js |       100 |       100 |       100 |       100 |
      contains.js             |       100 |       100 |       100 |       100 |
      warning.js              |       100 |       100 |       100 |       100 |
------------------------------|-----------|-----------|-----------|-----------|
All files                     |       100 |     83.33 |       100 |       100 |
------------------------------|-----------|-----------|-----------|-----------|


=============================== Coverage summary ===============================
Statements   : 100% ( 29/29 )
Branches     : 83.33% ( 5/6 )
Functions    : 100% ( 9/9 )
Lines        : 100% ( 29/29 )
================================================================================
[13:09:25] Finished 'mocha' after 475 ms
[13:09:25] Starting 'test'...
[13:09:25] Finished 'test' after 11 μs
```
