### PR TITLE
Fixes the reference to 'lib/MistypedPropsMixin' so node_modules named 'lib' don't hide it

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-    MistypedPropsMixin: require("lib/MistypedPropsMixin"),
+    MistypedPropsMixin: require("./lib/MistypedPropsMixin"),
 };


### PR DESCRIPTION
If there is a module in a project's node_modules folder called lib, node will search that folder for MistypedPropsMixin and come up empty. Fixing the reference like this ensures node will search relative to the react-mistyped-props module.
